### PR TITLE
Force ordering by id

### DIFF
--- a/scripts/search_SAMADhi.py
+++ b/scripts/search_SAMADhi.py
@@ -73,6 +73,7 @@ def main():
     else:
       objectClass = Result
       objectId = Result.result_id
+
     if opts.objid is not None:
       result = dbstore.find(objectClass,objectId==opts.objid)
     elif opts.path is not None:
@@ -81,6 +82,8 @@ def main():
       result = dbstore.find(objectClass,objectClass.name.like(unicode(opts.name)))
     else: 
       result = dbstore.find(objectClass)
+
+    result = result.order_by(objectId)
     # loop and print
     if opts.longOutput:
       for entry in result:


### PR DESCRIPTION
Since the recent change of layout, search results are ordered by name instead of id. This restore the old behavior and show results ordered by id.