### PR TITLE
Support for wildcards

### DIFF
--- a/scripts/search_SAMADhi.py
+++ b/scripts/search_SAMADhi.py
@@ -75,11 +75,11 @@ def main():
       objectId = Result.result_id
 
     if opts.objid is not None:
-      result = dbstore.find(objectClass,objectId==opts.objid)
+      result = dbstore.find(objectClass, objectId==opts.objid)
     elif opts.path is not None:
-      result = dbstore.find(objectClass,objectClass.path.like(unicode(opts.path)))
+      result = dbstore.find(objectClass, objectClass.path.like(unicode(opts.path.replace('*', '%').replace('?', '_'))))
     elif opts.name is not None:
-      result = dbstore.find(objectClass,objectClass.name.like(unicode(opts.name)))
+      result = dbstore.find(objectClass, objectClass.name.like(unicode(opts.name.replace('*', '%').replace('?', '_'))))
     else: 
       result = dbstore.find(objectClass)
 

--- a/scripts/search_SAMADhi.py
+++ b/scripts/search_SAMADhi.py
@@ -73,6 +73,7 @@ def main():
     else:
       objectClass = Result
       objectId = Result.result_id
+
     if opts.objid is not None:
       result = dbstore.find(objectClass,objectId==opts.objid)
     elif opts.path is not None:
@@ -81,6 +82,8 @@ def main():
       result = dbstore.find(objectClass,objectClass.name.like(unicode(opts.name)))
     else: 
       result = dbstore.find(objectClass)
+
+    result = result.order_by(objectId)
     # loop and print
     if opts.longOutput:
       for entry in result:


### PR DESCRIPTION
This PR adds basic support for sh-like wildcards ``*`` and ``?`` for users not familiar with SQL wildcards.

Example:

```bash
./search_SAMADhi.py sample --name "DoubleMu*"
```

This fixes https://github.com/cp3-llbb/GridIn/issues/29

PS: First commit is from #3 