### PR TITLE
Add new column to store extra sum of event weight

### DIFF
--- a/scripts/SAMADhi.py
+++ b/scripts/SAMADhi.py
@@ -78,6 +78,7 @@ class Sample(Storm):
   nevents = Int()
   normalization = Float()
   event_weight_sum = Float()
+  extras_event_weight_sum = Unicode() #  MEDIUMTEXT in MySQL
   luminosity = Float()
   processed_lumi = Unicode() #  MEDIUMTEXT in MySQL
   code_version = Unicode()
@@ -114,6 +115,7 @@ class Sample(Storm):
     self.nevents = sample.nevents
     self.normalization = sample.normalization
     self.event_weight_sum = sample.event_weight_sum
+    self.extras_event_weight_sum = sample.extras_event_weight_sum
     self.luminosity = sample.luminosity
     self.code_version = sample.code_version
     self.user_comment = sample.user_comment
@@ -153,6 +155,8 @@ class Sample(Storm):
     result += "  number of events: %s\n"%str(self.nevents)
     result += "  normalization: %s\n"%str(self.normalization)
     result += "  sum of event weight: %s\n"%str(self.event_weight_sum)
+    if self.extras_event_weight_sum:
+        result += "  has extras sum of event weight\n"
     result += "  (effective) luminosity: %s\n"%str(self.luminosity)
     if self.processed_lumi:
         result += "  has processed luminosity sections information\n"
@@ -330,12 +334,14 @@ class File(Storm):
     lfn = Unicode()  # Local file name: /store/
     pfn = Unicode()  # Physical file name: srm:// or root://
     event_weight_sum = Float()
+    extras_event_weight_sum = Unicode() #  MEDIUMTEXT in MySQL
     nevents = Int()
 
     sample = Reference(sample_id, "Sample.sample_id")
 
-    def __init__(self, lfn, pfn, event_weight_sum, nevents):
+    def __init__(self, lfn, pfn, event_weight_sum, extras_event_weight_sum, nevents):
         self.lfn = lfn
         self.pfn = pfn
         self.event_weight_sum = event_weight_sum
+        self.extras_event_weight_sum = extras_event_weight_sum
         self.nevents = nevents

--- a/scripts/SAMADhi.sql
+++ b/scripts/SAMADhi.sql
@@ -19,8 +19,7 @@ PRIMARY KEY (userID) ,
 UNIQUE (userName)
 ) ENGINE = INNODB;
 
-INSERT INTO 'users' (`userName`,`password`,`role`)
-VALUES ('adminUser','050f02a6a1221639d03d1ad935ff7fbf','ADMIN');
+INSERT INTO users (`userName`,`password`,`role`) VALUES ('adminUser','050f02a6a1221639d03d1ad935ff7fbf','ADMIN');
 
 CREATE TABLE dataset
 (
@@ -50,6 +49,7 @@ nevents_processed int,
 nevents int,
 normalization float NOT NULL DEFAULT 1.0, 
 event_weight_sum float NOT NULL DEFAULT 1.0,
+extras_event_weight_sum mediumtext,
 processed_lumi mediumtext,
 luminosity float,
 code_version varchar(255),
@@ -154,6 +154,7 @@ CREATE TABLE file
     lfn varchar(500) NOT NULL,
     pfn varchar(500) NOT NULL,
     event_weight_sum float,
+    extras_event_weight_sum mediumtext,
     nevents BIGINT,
     PRIMARY KEY (id),
     FOREIGN KEY (sample_id) REFERENCES sample(sample_id) ON DELETE CASCADE

--- a/scripts/v3_to_v4_upgrade.sql
+++ b/scripts/v3_to_v4_upgrade.sql
@@ -1,0 +1,7 @@
+-- Upgrade SAMADhi from v3 to v4
+-- Add a `extras_event_weight_sum` column to the sample table
+-- Add a `extras_event_weight_sum` column to the file table
+
+-- Alter sample table
+ALTER TABLE sample ADD extras_event_weight_sum mediumtext;
+ALTER TABLE file ADD extras_event_weight_sum mediumtext;


### PR DESCRIPTION
Proper support for scale variation and PDF systematics impose the use of different sum of event weight to properly normalize the samples. This PR update the structure of the `sample` and `file` table to add an extra column, `extras_event_weight_sum` of type `MEDIUMTEXT`. This field is intended to store a JSON representation of a dictionary, mapping between a string key (the *name* of the sum of event weights) and the sum as the value.

This structure allow a dynamic storage of an "unlimited" number of sum of weights (or none also) without having to change the database structure each time a new sum of weight is needed.

A migration script to upgrade current database structure is also included.

See also https://github.com/cp3-llbb/Framework/pull/147 for more details