### PR TITLE
Updates

### DIFF
--- a/scripts/SAMADhi.py
+++ b/scripts/SAMADhi.py
@@ -3,10 +3,30 @@ from storm.locals import *
 
 #db store connection
 
-def DbStore(login="llbb", password="ijvIg]Em0geqME", database="localhost/llbb"):
-  """create a database object and returns the db store from STORM"""
-  database = create_database("mysql://"+login+":"+password+"@"+database)
-  return Store(database)
+def DbStore(credentials='~/.samadhi'):
+    """create a database object and returns the db store from STORM"""
+
+    import json, os, stat
+    credentials = os.path.expanduser(credentials)
+    if not os.path.exists(credentials):
+        raise IOError('Credentials file %r not found.' % credentials)
+
+    # Check permission
+    mode = stat.S_IMODE(os.stat(credentials).st_mode)
+    if mode != int('400', 8):
+        raise IOError('Credentials file has wrong permission. Please execute \'chmod 400 %s\'' % credentials)
+
+    with open(credentials, 'r') as f:
+        data = json.load(f)
+
+        login = data['login']
+        password = data['password']
+        hostname = data['hostname'] if 'hostname' in data else 'localhost'
+        database = data['database']
+
+        db_connection_string = "mysql://%s:%s@%s/%s" % (login, password, hostname, database)
+        return Store(create_database(db_connection_string))
+
 
 #definition of the DB interface classes 
 

--- a/scripts/SAMADhi.py
+++ b/scripts/SAMADhi.py
@@ -168,8 +168,25 @@ class Sample(Storm):
     result += "  source sample: %s\n"%str(self.source_sample_id)
     if self.sample_id:
         result += "  %d files: \n" % (self.files.count())
-        for f in self.files:
+        front_files = []
+        last_file = None
+        if self.files.count() > 5:
+            c = 0
+            for f in self.files:
+                if c < 3:
+                    front_files.append(f)
+
+                if c == self.files.count() - 1:
+                    last_file = f
+                c += 1
+        else:
+            front_files = self.files
+
+        for f in front_files:
             result += "    - %s (%d entries)\n" % (str(f.lfn), f.nevents)
+        if last_file:
+            result += "    - ...\n"
+            result += "    - %s (%d entries)\n" % (str(last_file.lfn), last_file.nevents)
     else:
         # No way to know if some files are here
         result += "  no files"


### PR DESCRIPTION
Two different things:

 - First one reduce the printout when using `search_SAMADhi.py -l`. Instead of printing the whole list of file (which can be big for some samples), 5 lines max. are printed.
 - Second one move the credentials informations from `SAMADhi.py` to an external file (`~/.samadhi` by default). There's two advantages doing so:
    - you no longer need to edit the code to change the credentials, only *your* personal file. This means no more conflicts during a pull since you don't touch the code
    - you don't leak the credentials to the whole world by letting your python file readable by everyone.

Credentials are now stored in `~/.samadhi` into JSON, and looks like this:

```JSON
{
    "login": "llbb",
    "password": "...",
    "hostname": "...",
    "database": "..."
}
```

Permission of the file **must** be 400 (readable only by the user).

If this is merged, all users are expected to create the credentials file or the connection with the database won't work anymore.