### PR TITLE
Add script to set up for standalone usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ nosetests.xml
 *.sw?
 *~
 .pydevproject
+
+# standalone install symlinks
+install_python

--- a/README.md
+++ b/README.md
@@ -21,6 +21,6 @@ git clone -o upstream https://github.com/cp3-llbb/SAMADhi.git cp3_llbb/SAMADhi
 
 Standalone setup on ingrid:
 ```
-. ./installpy_standalone.sh
+source installpy_standalone.sh
 ```
 this will create an install tree and symlink if needed, and otherwise only set some environment variables.

--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ cd $MY_CMSSW_VERSION/src
 cmsenv
 git clone -o upstream https://github.com/cp3-llbb/SAMADhi.git cp3_llbb/SAMADhi
 ```
+
+Standalone setup on ingrid:
+```
+. ./installpy_standalone.sh
+```
+this will create an install tree and symlink if needed, and otherwise only set some environment variables.

--- a/installpy_standalone.sh
+++ b/installpy_standalone.sh
@@ -4,7 +4,11 @@
 # The install directory can be configured with the PREFIX environment variable
 #
 ## figure out where to install ($PREFIX/install_python, with default PREFIX=SAMDhi)
-thisscript="$(readlink -f ${0})"
+if [[ -z "${ZSH_NAME}" ]]; then
+  thisscript="$(readlink -f ${BASH_SOURCE})"
+else
+  thisscript="$(readlink -f ${0})"
+fi
 samadhipath="$(dirname ${thisscript})"
 if [[ -z "${PREFIX}" ]]; then
   PREFIX="${samadhipath}"

--- a/installpy_standalone.sh
+++ b/installpy_standalone.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 #
 # Creates a (symlinked) python install directory for SAMADhi and sets up environment variables,
 # such that the `from cp3_llbb.SAMADhi.SAMADhi ...` imports can also be used standalone on ingrid.
@@ -37,16 +36,23 @@ fi
 ## add PYTHONPATH (and LD_LIBRARY_PATH for python 2.7 if necessary)
 function checkAndAdd()
 {
-  local bk_ifs="${IFS}"
-  IFS=":"
   local in_path=""
-  exp_path=$(eval echo -e "\$${1}")
-  for apath in ${=exp_path}; do
-    if [[ "${apath}" == "${2}" ]]; then
-      in_path="yes"
-    fi
-  done
-  IFS="${bk_ifs}"
+  if [[ -z "${ZSH_NAME}" ]]; then
+    ## bash version
+    IFS=: local exp_path=${!1}
+    for apath in ${exp_path}; do
+      if [[ "${apath}" == "${2}" ]]; then
+        in_path="yes"
+      fi
+    done
+  else
+    ## zsh version
+    for apath in ${(Ps.:.)1}; do
+      if [[ "${apath}" == "${2}" ]]; then
+        in_path="yes"
+      fi
+    done
+  fi
   if [[ -z "${in_path}" ]]; then
     export ${1}="${2}:${exp_path}"
     echo "--> Added ${2} to ${1}"

--- a/installpy_standalone.sh
+++ b/installpy_standalone.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+#
+# Creates a (symlinked) python install directory for SAMADhi and sets up environment variables,
+# such that the `from cp3_llbb.SAMADhi.SAMADhi ...` imports can also be used standalone on ingrid.
+# The install directory can be configured with the PREFIX environment variable
+#
+## figure out where to install ($PREFIX/install_python, with default PREFIX=SAMDhi)
+thisscript="$(readlink -f ${0})"
+samadhipath="$(dirname ${thisscript})"
+if [[ -z "${PREFIX}" ]]; then
+  PREFIX="${samadhipath}"
+fi
+installpath="${PREFIX}/install_python"
+if [[ ! -d "${installpath}" ]]; then
+  echo "--> Installing into ${installpath}"
+  mkdir -p "${installpath}/cp3_llbb/"
+fi
+## __init__.py for cp3_llbb
+hatinitpy="${installpath}/cp3_llbb/__init__.py"
+if [[ ! -f "${hatinitpy}" ]]; then
+  echo "" > "${hatinitpy}"
+fi
+## symlink
+installpy="${installpath}/cp3_llbb/SAMADhi"
+if [[ ! -a "${installpy}" ]]; then
+  ln -s "${samadhipath}/python" "${installpy}"
+  echo "--> Created symlink to SAMADhi"
+elif [[ ! ( -L "${installpy}" ) ]]; then
+  echo "--> ${installpy} exists, but is not a symlink"
+  exit 1
+fi
+## __init__.py for cp3_llbb/SAMADhi
+pkginitpy="${installpy}/__init__.py"
+if [[ ! -f "${pkginitpy}" ]]; then
+  echo "" > "${pkginitpy}"
+fi
+## add PYTHONPATH (and LD_LIBRARY_PATH for python 2.7 if necessary)
+function checkAndAdd()
+{
+  local bk_ifs="${IFS}"
+  IFS=":"
+  local in_path=""
+  exp_path=$(eval echo -e "\$${1}")
+  for apath in ${=exp_path}; do
+    if [[ "${apath}" == "${2}" ]]; then
+      in_path="yes"
+    fi
+  done
+  IFS="${bk_ifs}"
+  if [[ -z "${in_path}" ]]; then
+    export ${1}="${2}:${exp_path}"
+    echo "--> Added ${2} to ${1}"
+  fi
+}
+checkAndAdd "PYTHONPATH" "${installpath}"
+checkAndAdd "LD_LIBRARY_PATH" "/nfs/soft/python/python-2.7.5-sl6_amd64_gcc44/lib"


### PR DESCRIPTION
I tried with `zsh` and `bash`, but may have missed something.
On a related point: does anyone have an idea to avoid hardcoding a custom python2.7 on ingrid (in the shebang of the scripts and in `SAMADhi.py`) inside cmssw? (outside we could easily solve it by setting PATH and PYTHONPATH). I think the problem is that storm is not there in the cmssw externals.